### PR TITLE
Expand selling module navigation

### DIFF
--- a/nav-selling.md
+++ b/nav-selling.md
@@ -19,3 +19,29 @@ Main subfolders:
 - selling_dashboard
 - workspace
 
+Key doctypes (in `erpnext/selling/doctype`):
+
+- `customer` – customer master and dashboard
+- `quotation` – quote document and related items
+- `sales_order` – sales order and items
+- `product_bundle` – bundled products
+- `selling_settings` – module configuration
+- other supporting doctypes like `customer_credit_limit`, `party_specific_item`, `sms_center`
+
+Important pages (`erpnext/selling/page`):
+
+- `point_of_sale` – Point of Sale interface with JS and Python controllers
+- `sales_funnel` – sales funnel dashboard page
+
+Reports (`erpnext/selling/report`): numerous built‑in sales analytics reports such as `sales_order_analysis`, `sales_analytics`, `quotation_trends`, and more.
+
+Dashboards and workspace:
+
+- `dashboard_chart` and `number_card` provide chart and card JSON definitions
+- `selling_dashboard/selling` and `workspace/selling` define the selling workspace
+- `module_onboarding/selling` and `onboarding_step/*` configure onboarding flow
+
+Related utilities:
+
+- `erpnext/public/js/utils/sales_common.js` – shared client‑side logic
+- `erpnext/controllers/selling_controller.py` – base controller used by doctypes


### PR DESCRIPTION
## Summary
- provide extra details in navigation for the Selling module

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -k selling -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_b_686f8d7cc22c8321a87ffb3ee00d0d7f