### PR TITLE
Update navigation for Bulk Transaction module

### DIFF
--- a/nav-bulk_transaction.md
+++ b/nav-bulk_transaction.md
@@ -7,3 +7,18 @@ Main subfolders:
 - __init__.py
 - doctype
 
+### Doctypes
+
+- `bulk_transaction_log` - summary log for a specific date
+- `bulk_transaction_log_detail` - records each created document
+
+### Related Files
+
+- `erpnext/utilities/bulk_transaction.py` - server side processing and retry logic
+- `erpnext/public/js/bulk_transaction_processing.js` - helper used by list views
+- `erpnext/hooks.py` - schedules periodic `bulk_transaction.retry`
+
+List view scripts across `buying`, `selling`, `accounts` and `stock` use the
+`bulk_transaction_processing.create` helper to generate related documents in
+bulk from selected rows.
+


### PR DESCRIPTION
## Summary
- expand the Bulk Transaction navigation doc with more context

## Testing
- `pytest -k bulk_transaction -q` *(fails: ModuleNotFoundError: No module named 'frappe')*
- `pre-commit run --files nav-bulk_transaction.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686f8de7caa48321afa8c09bf49fc60f