### PR TITLE
Improve subcontracting navigation

### DIFF
--- a/nav-subcontracting.md
+++ b/nav-subcontracting.md
@@ -7,3 +7,23 @@ Main subfolders:
 - __init__.py
 - doctype
 
+### Doctypes
+
+- subcontracting_bom
+- subcontracting_order
+- subcontracting_order_item
+- subcontracting_order_service_item
+- subcontracting_order_supplied_item
+- subcontracting_receipt
+- subcontracting_receipt_item
+- subcontracting_receipt_supplied_item
+
+### Related Code
+
+- `erpnext/controllers/subcontracting_controller.py` – shared business logic for orders and receipts
+- `erpnext/controllers/tests/test_subcontracting_controller.py` – controller tests
+- `erpnext/patches/v15_0/rename_subcontracting_fields.py`
+- `erpnext/patches/v14_0/copy_is_subcontracted_value_to_is_old_subcontracting_flow.py`
+- `erpnext/patches/v14_0/change_is_subcontracted_fieldtype.py`
+
+This module integrates with stock and manufacturing workflows to handle outsourced production.


### PR DESCRIPTION
## Summary
- document subcontracting subfolders and related code

## Testing
- `pre-commit run --files nav-subcontracting.md` *(fails: command not found)*
- `pytest -k subcontracting -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_b_686f8ded29b4832195591e24a7242640