### PR TITLE
Improve EDI navigation docs

### DIFF
--- a/nav-edi.md
+++ b/nav-edi.md
@@ -4,6 +4,24 @@ Source directory: `erpnext/edi`
 
 Main subfolders:
 
-- __init__.py
-- doctype
+- `__init__.py`
+- `doctype`
+  - `code_list`
+    - `code_list.json` – doctype schema
+    - `code_list.py` – server logic
+    - `code_list.js` – form script
+    - `code_list_list.js` – list view settings
+    - `code_list_import.py` – genericode import helpers
+    - `code_list_import.js` – import dialog
+    - `test_code_list.py`
+  - `common_code`
+    - `common_code.json`
+    - `common_code.py`
+    - `common_code.js`
+    - `common_code_list.js`
+    - `test_common_code.py`
+
+Related entries:
+
+- `hooks.py` registers `doctype_list_js` for the importer UI.
 


### PR DESCRIPTION
## Summary
- expand `nav-edi.md` with details on doctypes and related scripts

## Testing
- `pytest erpnext/edi` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_b_686f8df54efc8321a853f9f537a07da5